### PR TITLE
add waitWhileBusy, change SFC_WRITE

### DIFF
--- a/src/ArduboyFX.cpp
+++ b/src/ArduboyFX.cpp
@@ -412,6 +412,15 @@ void FX::writeSavePage(uint16_t page, uint8_t* buffer)
   disable();
 }
 
+void FX::waitWhileBusy()
+{
+  enable();
+  writeByte(SFC_READSTATUS1);
+  while(readByte() & 1)
+    ; // wait while BUSY status bit is set
+  disable();
+}
+
 void FX::drawBitmap(int16_t x, int16_t y, uint24_t address, uint8_t frame, uint8_t mode)
 {
   // read bitmap dimensions from flash

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -26,7 +26,7 @@ constexpr uint8_t SFC_READSTATUS2       = 0x35;
 constexpr uint8_t SFC_READSTATUS3       = 0x15;
 constexpr uint8_t SFC_READ              = 0x03;
 constexpr uint8_t SFC_WRITE_ENABLE      = 0x06;
-constexpr uint8_t SFC_WRITE             = 0x04;
+constexpr uint8_t SFC_WRITE             = 0x02;
 constexpr uint8_t SFC_ERASE             = 0x20;
 constexpr uint8_t SFC_RELEASE_POWERDOWN = 0xAB;
 constexpr uint8_t SFC_POWERDOWN         = 0xB9;
@@ -254,6 +254,8 @@ class FX
     static void eraseSaveBlock(uint16_t page);
 
     static void writeSavePage(uint16_t page, uint8_t* buffer);
+    
+    static void waitWhileBusy(); // wait for outstanding erase or write to finish
 
     static void drawBitmap(int16_t x, int16_t y, uint24_t address, uint8_t frame, uint8_t mode) __attribute__((noinline));
 


### PR DESCRIPTION
Added a method to wait until the previously issued sector erase (45-400 ms) or program (0.7-3 ms) command has completed; it waits until the BUSY status bit is cleared. 
I didn't insert calls to this method from eraseSaveBlock or writeSavePage in case the user wanted to use the wait cycles for other stuff:
```c++
FX::eraseSaveBlock(...);
// long wait here. could do a bunch of stuff
for(each page)
{
    // compute next page here
    FX::waitWhileBusy();
    FX::writeSavePage(page, ...);
}
FX::waitWhileBusy();
```