### PR TITLE
Add Various Template and Reference-Parameter Functions

### DIFF
--- a/src/ArduboyFX.cpp
+++ b/src/ArduboyFX.cpp
@@ -118,6 +118,16 @@ void FX::begin(uint16_t developmentDataPage, uint16_t developmentSavePage)
   wakeUp();
 }
 
+void FX::readJedecID(JedecID & id)
+{
+  enable();
+  writeByte(SFC_JEDEC_ID);
+  id.manufacturer = readByte();
+  id.device = readByte();
+  id.size = readByte();
+  disable();
+}
+
 void FX::readJedecID(JedecID* id)
 {
   enable();

--- a/src/ArduboyFX.cpp
+++ b/src/ArduboyFX.cpp
@@ -527,7 +527,7 @@ uint8_t FX::loadGameState(uint8_t* gameState, size_t size) // ~54 bytes
   return result;
 }
 
-void FX::saveGameState(uint8_t* gameState, size_t size) // ~152 bytes locates free space in 4K save block and saves the GamesState.
+void FX::saveGameState(const uint8_t* gameState, size_t size) // ~152 bytes locates free space in 4K save block and saves the GamesState.
 {                                                       //            if there is not enough free space, the block is erased prior to saving
  register size_t sz asm("r18") = size;
  #ifdef ARDUINO_ARCH_AVR

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -355,6 +355,20 @@ class FX
 
     static uint8_t loadGameState(uint8_t* gameState, size_t size) __attribute__ ((noinline)); //loads GameState from program exclusive 4K save data block.
 
+    /// @brief Saves an object into an exclusive 4KB save data block.
+    /// @tparam Type The type of the object to be saved.
+    /// @param object The object to be saved.
+    /// @warning
+    /// `Type` should be:
+    /// * _[trivially copyable](https://en.cppreference.com/w/cpp/named_req/TriviallyCopyable)_
+    /// * a _[standard-layout](https://en.cppreference.com/w/cpp/language/data_members#Standard-layout)_ type
+    /// Attempting to read an object that does not meet these restrictions will result in _undefined behaviour_.
+    template<typename Type>
+    static void saveObject(const Type & object)
+    {
+      saveGameState(reinterpret_cast<const uint8_t *>(&object), sizeof(object));
+    }
+
     static void saveGameState(const uint8_t* gameState, size_t size) __attribute__ ((noinline)); // Saves GameState in RAM to programes exclusive 4K save data block.
 
     static void eraseSaveBlock(uint16_t page); // erases 4K flash block

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -320,7 +320,7 @@ class FX
 
     static uint8_t readEnd() __attribute__ ((noinline)); //read the last prefetched byte from the current flash location and ends the read command
 
-    /// @brief Reads an object from the specified address.
+    /// @brief Reads an object from the specified address in the game's data section.
     /// @tparam Type The type of the object to be read.
     /// @param address The address of the object in flash memory.
     /// @param object An object into which the target object will be read.
@@ -330,7 +330,7 @@ class FX
     /// * a _[standard-layout](https://en.cppreference.com/w/cpp/language/data_members#Standard-layout)_ type
     /// Attempting to read an object that does not meet these restrictions will result in _undefined behaviour_.
     template<typename Type>
-    static void readObject(uint24_t address, Type & object)
+    static void readDataObject(uint24_t address, Type & object)
     {
       readDataBytes(address, reinterpret_cast<uint8_t *>(&object), sizeof(object));
     }

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -354,7 +354,7 @@ class FX
 
     static void readSaveBytes(uint24_t address, uint8_t* buffer, size_t length);
 
-    /// @brief Loads a saved object from an exclusive 4KB save data block.
+    /// @brief Loads a saved game state object from an exclusive 4KB save data block.
     /// @tparam Type The type of the object to be loaded.
     /// @param object The object into which the saved state will be loaded.
     /// @warning
@@ -363,7 +363,7 @@ class FX
     /// * a _[standard-layout](https://en.cppreference.com/w/cpp/language/data_members#Standard-layout)_ type
     /// Attempting to read an object that does not meet these restrictions will result in _undefined behaviour_.
     template<typename Type>
-    static void loadObject(Type & object)
+    static void loadGameState(Type & object)
     {
       loadGameState(reinterpret_cast<uint8_t *>(&object), sizeof(object));
     }

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -320,6 +320,21 @@ class FX
 
     static uint8_t readEnd() __attribute__ ((noinline)); //read the last prefetched byte from the current flash location and ends the read command
 
+    /// @brief Reads an object from the specified address.
+    /// @tparam Type The type of the object to be read.
+    /// @param address The address of the object in flash memory.
+    /// @param object An object into which the target object will be read.
+    /// @warning
+    /// `Type` should be:
+    /// * _[trivially copyable](https://en.cppreference.com/w/cpp/named_req/TriviallyCopyable)_
+    /// * a _[standard-layout](https://en.cppreference.com/w/cpp/language/data_members#Standard-layout)_ type
+    /// Attempting to read an object that does not meet these restrictions will result in _undefined behaviour_.
+    template<typename Type>
+    static void readObject(uint24_t address, Type & object)
+    {
+      readDataBytes(address, reinterpret_cast<uint8_t *>(&object), sizeof(object));
+    }
+
     static void readDataBytes(uint24_t address, uint8_t* buffer, size_t length);
 
     static void readSaveBytes(uint24_t address, uint8_t* buffer, size_t length);

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -370,7 +370,7 @@ class FX
 
     static uint8_t loadGameState(uint8_t* gameState, size_t size) __attribute__ ((noinline)); //loads GameState from program exclusive 4K save data block.
 
-    /// @brief Saves an object into an exclusive 4KB save data block.
+    /// @brief Saves a game state object into an exclusive 4KB save data block.
     /// @tparam Type The type of the object to be saved.
     /// @param object The object to be saved.
     /// @warning
@@ -379,7 +379,7 @@ class FX
     /// * a _[standard-layout](https://en.cppreference.com/w/cpp/language/data_members#Standard-layout)_ type
     /// Attempting to read an object that does not meet these restrictions will result in _undefined behaviour_.
     template<typename Type>
-    static void saveObject(const Type & object)
+    static void saveGameState(const Type & object)
     {
       saveGameState(reinterpret_cast<const uint8_t *>(&object), sizeof(object));
     }

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -233,6 +233,20 @@ class FX
 
     static void seekData(uint24_t address); // selects flashaddress of program data area for reading and starts the first read
 
+    /// @brief Seeks an element of an array.
+    /// @tparam Type The type of the element to be read.
+    /// @param address The base address of the array.
+    /// @param index The index of the array element.
+    template<typename Type>
+    static void seekArrayElement(uint24_t address, uint8_t index)
+    {
+      // Note: By the laws of the language this should never happen.
+      // This assert exists only as a precaution against e.g. weird compiler extensions.
+      static_assert(sizeof(Type) > 0, "Cannot use a Type with a size of 0.")
+
+      seekData(address + (index * sizeof(Type)));
+    }
+
     static void seekDataArray(uint24_t address, uint8_t index, uint8_t offset, uint8_t elementSize);
 
     static void seekSave(uint24_t address) __attribute__ ((noinline)); // selects flashaddress of program save area for reading and starts the first read

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -337,6 +337,21 @@ class FX
 
     static void readDataBytes(uint24_t address, uint8_t* buffer, size_t length);
 
+    /// @brief Reads an object from the specified address in the game's save section.
+    /// @tparam Type The type of the object to be read.
+    /// @param address The address of the object in flash memory.
+    /// @param object An object into which the target object will be read.
+    /// @warning
+    /// `Type` should be:
+    /// * _[trivially copyable](https://en.cppreference.com/w/cpp/named_req/TriviallyCopyable)_
+    /// * a _[standard-layout](https://en.cppreference.com/w/cpp/language/data_members#Standard-layout)_ type
+    /// Attempting to read an object that does not meet these restrictions will result in _undefined behaviour_.
+    template<typename Type>
+    static void readSaveObject(uint24_t address, Type & object)
+    {
+      readSaveBytes(address, reinterpret_cast<uint8_t *>(&object), sizeof(object));
+    }
+
     static void readSaveBytes(uint24_t address, uint8_t* buffer, size_t length);
 
     /// @brief Loads a saved object from an exclusive 4KB save data block.

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -211,6 +211,10 @@ class FX
 
     static void begin(uint16_t datapage, uint16_t savepage); // Initializes flash memory. Use when program depends on both data and save data in flash memory
 
+    /// @brief Reads the JedecID of the attached flash chip.
+    /// @param id An object into which the ID will be read.
+    static void readJedecID(JedecID & id);
+
     static void readJedecID(JedecID* id);
 
     static bool detect(); //detect presence of initialized flash memory

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -300,6 +300,20 @@ class FX
 
     static uint32_t readPendingLastUInt32(); //read a partly prefetched a 32-bit word from the current flash location
 
+    /// @brief Reads an object from the current flash location.
+    /// @tparam Type The type of the object to be read.
+    /// @param object An object into which the target object will be read.
+    /// @warning
+    /// `Type` should be:
+    /// * _[trivially copyable](https://en.cppreference.com/w/cpp/named_req/TriviallyCopyable)_
+    /// * a _[standard-layout](https://en.cppreference.com/w/cpp/language/data_members#Standard-layout)_ type
+    /// Attempting to read an object that does not meet these restrictions will result in _undefined behaviour_.
+    template<typename Type>
+    static void readObject(Type & object)
+    {
+      readBytes(reinterpret_cast<uint8_t *>(&object), sizeof(object));
+    }
+
     static void readBytes(uint8_t* buffer, size_t length);// read a number of bytes from the current flash location
 
     static void readBytesEnd(uint8_t* buffer, size_t length); // read a number of bytes from the current flash location and ends the read command

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -341,7 +341,7 @@ class FX
 
     static uint8_t loadGameState(uint8_t* gameState, size_t size) __attribute__ ((noinline)); //loads GameState from program exclusive 4K save data block.
 
-    static void saveGameState(uint8_t* gameState, size_t size) __attribute__ ((noinline)); // Saves GameState in RAM to programes exclusive 4K save data block.
+    static void saveGameState(const uint8_t* gameState, size_t size) __attribute__ ((noinline)); // Saves GameState in RAM to programes exclusive 4K save data block.
 
     static void eraseSaveBlock(uint16_t page); // erases 4K flash block
 

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -339,6 +339,20 @@ class FX
 
     static void readSaveBytes(uint24_t address, uint8_t* buffer, size_t length);
 
+    /// @brief Loads a saved object from an exclusive 4KB save data block.
+    /// @tparam Type The type of the object to be loaded.
+    /// @param object The object into which the saved state will be loaded.
+    /// @warning
+    /// `Type` should be:
+    /// * _[trivially copyable](https://en.cppreference.com/w/cpp/named_req/TriviallyCopyable)_
+    /// * a _[standard-layout](https://en.cppreference.com/w/cpp/language/data_members#Standard-layout)_ type
+    /// Attempting to read an object that does not meet these restrictions will result in _undefined behaviour_.
+    template<typename Type>
+    static void loadObject(Type & object)
+    {
+      loadGameState(reinterpret_cast<uint8_t *>(&object), sizeof(object));
+    }
+
     static uint8_t loadGameState(uint8_t* gameState, size_t size) __attribute__ ((noinline)); //loads GameState from program exclusive 4K save data block.
 
     static void saveGameState(const uint8_t* gameState, size_t size) __attribute__ ((noinline)); // Saves GameState in RAM to programes exclusive 4K save data block.

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -247,6 +247,25 @@ class FX
       seekData(address + (index * sizeof(Type)));
     }
 
+    /// @brief Seeks a member of an object that is an element of an array.
+    /// @tparam Type The type of the elements in the array.
+    /// @param address The base address of the array.
+    /// @param index The index of the array element.
+    /// @param offset The offset of the member of the array element.
+    /// @note
+    /// It is intended that the value of `offset` be acquired using the
+    /// `offsetof` macro from `stddef.h`, as this is the safest way
+    /// to obtain the offset of an object member.
+    template<typename Type>
+    static void seekArrayElementMember(uint24_t address, uint8_t index, size_t offset)
+    {
+      // Note: By the laws of the language this should never happen.
+      // This assert exists only as a precaution against e.g. weird compiler extensions.
+      static_assert(sizeof(Type) > 0, "Cannot use a Type with a size of 0.")
+
+      seekData(address + ((index * sizeof(Type)) + offset));
+    }
+
     static void seekDataArray(uint24_t address, uint8_t index, uint8_t offset, uint8_t elementSize);
 
     static void seekSave(uint24_t address) __attribute__ ((noinline)); // selects flashaddress of program save area for reading and starts the first read


### PR DESCRIPTION
Adds:
* `readJedecID(JedecID & id)` - Same as `readJedecID(JedecID * id), but uses a reference instead and is thus never `nullptr`.
* `seekArrayElement<Type>(uint24_t address, uint8_t index)` - Seeks an array element.
  * Performs a `static_assert` to ensure that `sizeof(Type) > 0`, though by the laws of C++ that expression should _always_ be true.
  * Implemented manually rather than deferring to `seekDataArray` because `seekDataArray` manually handles the case of size being `0` at runtime and this version instead ensures that size is never `0` at compile time, thus this should be capable of producing smaller code.
* `seekArrayElementMember<Type>(uint24_t address, uint8_t index, size_t offset)` - Seeks a member of an array element.
  * I'm presuming this is the sort of thing `seekDataArray`'s `offset` parameter is indended to do. I made this a separate function from `seekArrayElement` because seeking a specific member of an object in an array seems like a very niche thing to do, and is liable to confuse people who are only looking to read a single element from an array. The majority of users are going to want the `seekArrayElement` version.
* `readObject<Type>(Type & object)` - A thin, type-safe wrapper around `readBytes`.
  * Absolves the user of having to deal with casting, `&` or `sizeof`, and thus prevents errors that would arise from manually dealing with boilerplate.
* `readDataObject<Type>(uint24_t address, Type & object)` - A thin, type-safe wrapper around `readDataBytes`.
  * The documenation is probably off because I basically had to guess at what `readDataBytes` does.
* `readSaveObject<Type>(uint24_t address, Type & object)` - A thin, type-safe wrapper around `readSaveBytes`.
  * Again, the documenation is probably off because I basically had to guess at what `readSaveBytes` does.
* `loadObject<Type>(Type & object)` - A thin, type-safe wrapper around `loadGameState`
  * I opted for `Object` rather than `GameState` because it can be used for more than just games and because the words 'game state' get used (and 'overloaded') quite a lot in game development so giving them yet another meaning is likely to cause more confusion for beginners.
  * Again, absolves the user of having to deal with casting, `&` or `sizeof`, and thus prevents errors that would arise from manually dealing with boilerplate.
* `saveObject<Type>(const Type & object)` - A thin, type-safe wrapper around `saveGameState`

I was going to make a wrapper for `readDataArray`, but I was really confused about what it was supposed to be doing.

I also wondered if `writeSavePage` might benefit from being templated, but I don't know enough about what it's actually supposed to be doing to be able to properly document a wrapper for it.
