### PR TITLE
Improve Portability

### DIFF
--- a/src/ArduboyFX.cpp
+++ b/src/ArduboyFX.cpp
@@ -1,6 +1,9 @@
 #include "ArduboyFX.h"
 #include <wiring.c>
 
+// For Arduboy2Base::sBuffer, WIDTH, HEIGHT
+#include <Arduboy2.h>
+
 uint16_t FX::programDataPage; // program read only data location in flash memory
 uint16_t FX::programSavePage; // program read and write data location in flash memory
 Font     FX::font;

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -164,41 +164,48 @@ struct FrameData
 class FX
 {
   public:
-    static inline void enableOLED() __attribute__((always_inline)) // selects OLED display.
+    [[gnu::always_inline]]
+    static inline void enableOLED() // selects OLED display.
     {
       CS_PORT &= ~(1 << CS_BIT);
     };
 
-    static inline void disableOLED() __attribute__((always_inline)) // deselects OLED display.
+    [[gnu::always_inline]]
+    static inline void disableOLED() // deselects OLED display.
     {
       CS_PORT |=  (1 << CS_BIT);
     };
 
-    static inline void enable() __attribute__((always_inline)) // selects external flash memory and allows new commands
+    [[gnu::always_inline]]
+    static inline void enable() // selects external flash memory and allows new commands
     {
       FX_PORT  &= ~(1 << FX_BIT);
     };
 
-    static inline void disable() __attribute__((always_inline)) // deselects external flash memory and ends the last command
+    [[gnu::always_inline]]
+    static inline void disable() // deselects external flash memory and ends the last command
     {
       FX_PORT  |=  (1 << FX_BIT);
     };
 
-    static inline void wait() __attribute__((always_inline)) // wait for a pending flash transfer to complete
+    [[gnu::always_inline]]
+    static inline void wait() // wait for a pending flash transfer to complete
     {
       while ((SPSR & _BV(SPIF)) == 0);
     }
 
     static uint8_t writeByte(uint8_t data); // write a single byte to flash memory.
 
-    static inline void writeByteBeforeWait(uint8_t data) __attribute__((always_inline))
+    [[gnu::always_inline]]
+    static inline void writeByteBeforeWait(uint8_t data)
     {
       SPDR = data;
       asm volatile("nop\n");
       wait();
     }
 
-    static inline void writeByteAfterWait(uint8_t data) __attribute__((always_inline))
+    [[gnu::always_inline]]
+    static inline void writeByteAfterWait(uint8_t data)
     {
       wait();
       SPDR = data;
@@ -275,29 +282,36 @@ class FX
 
     static void seekDataArray(uint24_t address, uint8_t index, uint8_t offset, uint8_t elementSize);
 
-    static void seekSave(uint24_t address) __attribute__ ((noinline)); // selects flashaddress of program save area for reading and starts the first read
+    [[gnu::noinline]]
+    static void seekSave(uint24_t address); // selects flashaddress of program save area for reading and starts the first read
 
-    static inline uint8_t readUnsafe() __attribute__((always_inline)) // read flash data without performing any checks and starts the next read.
+    [[gnu::always_inline]]
+    static inline uint8_t readUnsafe() // read flash data without performing any checks and starts the next read.
     {
       uint8_t result = SPDR;
       SPDR = 0;
       return result;
     };
 
-    static inline uint8_t readUnsafeEnd() __attribute__((always_inline))
+    [[gnu::always_inline]]
+    static inline uint8_t readUnsafeEnd()
     {
       uint8_t result = SPDR;
       disable();
       return result;
     };
 
-    static uint8_t readPendingUInt8() __attribute__ ((noinline));    //read a prefetched byte from the current flash location
+    [[gnu::noinline]]
+    static uint8_t readPendingUInt8();    //read a prefetched byte from the current flash location
 
-    static uint8_t readPendingLastUInt8() __attribute__ ((noinline));    //depreciated use readEnd() instead (see below)
+    [[gnu::noinline]]
+    static uint8_t readPendingLastUInt8();    //depreciated use readEnd() instead (see below)
 
-    static uint16_t readPendingUInt16() __attribute__ ((noinline)) __attribute__ ((naked)); //read a partly prefetched 16-bit word from the current flash location
+    [[gnu::noinline, gnu::naked]]
+    static uint16_t readPendingUInt16(); //read a partly prefetched 16-bit word from the current flash location
 
-    static uint16_t readPendingLastUInt16() __attribute__ ((noinline)) __attribute__ ((naked)); //read a partly prefetched 16-bit word from the current flash location
+    [[gnu::noinline, gnu::naked]]
+    static uint16_t readPendingLastUInt16(); //read a partly prefetched 16-bit word from the current flash location
 
     static uint24_t readPendingUInt24() ; //read a partly prefetched 24-bit word from the current flash location
 
@@ -325,7 +339,8 @@ class FX
 
     static void readBytesEnd(uint8_t* buffer, size_t length); // read a number of bytes from the current flash location and ends the read command
 
-    static uint8_t readEnd() __attribute__ ((noinline)); //read the last prefetched byte from the current flash location and ends the read command
+    [[gnu::noinline]]
+    static uint8_t readEnd(); //read the last prefetched byte from the current flash location and ends the read command
 
     /// @brief Reads an object from the specified address in the game's data section.
     /// @tparam Type The type of the object to be read.
@@ -375,7 +390,8 @@ class FX
       loadGameState(reinterpret_cast<uint8_t *>(&object), sizeof(object));
     }
 
-    static uint8_t loadGameState(uint8_t* gameState, size_t size) __attribute__ ((noinline)); //loads GameState from program exclusive 4K save data block.
+    [[gnu::noinline]]
+    static uint8_t loadGameState(uint8_t* gameState, size_t size); //loads GameState from program exclusive 4K save data block.
 
     /// @brief Saves a game state object into an exclusive 4KB save data block.
     /// @tparam Type The type of the object to be saved.
@@ -391,7 +407,8 @@ class FX
       saveGameState(reinterpret_cast<const uint8_t *>(&object), sizeof(object));
     }
 
-    static void saveGameState(const uint8_t* gameState, size_t size) __attribute__ ((noinline)); // Saves GameState in RAM to programes exclusive 4K save data block.
+    [[gnu::noinline]]
+    static void saveGameState(const uint8_t* gameState, size_t size); // Saves GameState in RAM to programes exclusive 4K save data block.
 
     static void eraseSaveBlock(uint16_t page); // erases 4K flash block
 
@@ -399,13 +416,15 @@ class FX
 
     static void waitWhileBusy(); // wait for outstanding erase or write to finish
 
-    static void drawBitmap(int16_t x, int16_t y, uint24_t address, uint8_t frame, uint8_t mode) __attribute__((noinline));
+    [[gnu::noinline]]
+    static void drawBitmap(int16_t x, int16_t y, uint24_t address, uint8_t frame, uint8_t mode);
 
     static void setFrame(uint24_t frame, uint8_t repeat)__attribute__ ((noinline));
 
     static uint8_t drawFrame();
 
-    static uint24_t drawFrame(uint24_t address) __attribute__((noinline)); // draw a list of bitmap images located at address
+    [[gnu::noinline]]
+    static uint24_t drawFrame(uint24_t address); // draw a list of bitmap images located at address
 
     static void readDataArray(uint24_t address, uint8_t index, uint8_t offset, uint8_t elementSize, uint8_t* buffer, size_t length);
 
@@ -466,7 +485,8 @@ class FX
 
     /* general optimized functions */
 
-    static inline uint16_t multiplyUInt8 (uint8_t a, uint8_t b) __attribute__((always_inline))
+    [[gnu::always_inline]]
+    static inline uint16_t multiplyUInt8 (uint8_t a, uint8_t b)
     {
      #ifdef ARDUINO_ARCH_AVR
       uint16_t result;
@@ -485,7 +505,8 @@ class FX
      #endif
     }
 
-    static inline uint8_t bitShiftLeftUInt8(uint8_t bit) __attribute__((always_inline)) //fast (1 << (bit & 7))
+    [[gnu::always_inline]]
+    static inline uint8_t bitShiftLeftUInt8(uint8_t bit) //fast (1 << (bit & 7))
     {
      #ifdef ARDUINO_ARCH_AVR
       uint8_t result;
@@ -507,7 +528,8 @@ class FX
      #endif
     }
 
-    static inline uint8_t bitShiftRightUInt8(uint8_t bit) __attribute__((always_inline)) //fast (0x80 >> (bit & 7))
+    [[gnu::always_inline]]
+    static inline uint8_t bitShiftRightUInt8(uint8_t bit) //fast (0x80 >> (bit & 7))
     {
      #ifdef ARDUINO_ARCH_AVR
       uint8_t result;
@@ -529,7 +551,8 @@ class FX
      #endif
     }
 
-    static inline uint8_t bitShiftLeftMaskUInt8(uint8_t bit) __attribute__((always_inline)) //fast (0xFF << (bit & 7) & 0xFF)
+    [[gnu::always_inline]]
+    static inline uint8_t bitShiftLeftMaskUInt8(uint8_t bit) //fast (0xFF << (bit & 7) & 0xFF)
     {
      #ifdef ARDUINO_ARCH_AVR
       uint8_t result;
@@ -552,7 +575,8 @@ class FX
      #endif
     }
 
-    static inline uint8_t bitShiftRightMaskUInt8(uint8_t bit) __attribute__((always_inline)) //fast (0xFF >> (bit & 7))
+    [[gnu::always_inline]]
+    static inline uint8_t bitShiftRightMaskUInt8(uint8_t bit) //fast (0xFF >> (bit & 7))
     {
      #ifdef ARDUINO_ARCH_AVR
       uint8_t result;

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -49,15 +49,15 @@ constexpr uint8_t dbfEndFrame     = 6; // last bitmap image of a frame
 constexpr uint8_t dbfLastFrame    = 7; // last bitmap image of the last frame
 
 // drawBitmap modes with same behaviour as Arduboy library drawBitmap modes
-constexpr uint8_t dbmBlack   = _BV(dbfReverseBlack) |   // white pixels in bitmap will be drawn as black pixels on display
-                               _BV(dbfBlack) |          // black pixels in bitmap will not change pixels on display
-                               _BV(dbfWhiteBlack);      // (same as sprites drawErase)
+constexpr uint8_t dbmBlack   = (1 << dbfReverseBlack) |   // white pixels in bitmap will be drawn as black pixels on display
+                               (1 << dbfBlack) |          // black pixels in bitmap will not change pixels on display
+                               (1 << dbfWhiteBlack);      // (same as sprites drawErase)
 
-constexpr uint8_t dbmWhite   = _BV(dbfWhiteBlack);      // white pixels in bitmap will be drawn as white pixels on display
+constexpr uint8_t dbmWhite   = (1 << dbfWhiteBlack);      // white pixels in bitmap will be drawn as white pixels on display
                                                         // black pixels in bitmap will not change pixels on display
                                                         //(same as sprites drawSelfMasked)
 
-constexpr uint8_t dbmInvert  = _BV(dbfInvert);          // when a pixel in bitmap has a different color than on display the
+constexpr uint8_t dbmInvert  = (1 << dbfInvert);          // when a pixel in bitmap has a different color than on display the
                                                         // pixel on display will be drawn as white. In all other cases the
                                                         // pixel will be drawn as black
 // additional drawBitmap modes
@@ -65,14 +65,14 @@ constexpr uint8_t dbmNormal     = 0;                    // White pixels in bitma
 constexpr uint8_t dbmOverwrite  = 0;                    // Black pixels in bitmap will be drawn as black pixels on display
                                                         // (Same as sprites drawOverwrite)
 
-constexpr uint8_t dbmReverse = _BV(dbfReverseBlack);    // White pixels in bitmap will be drawn as black pixels on display
+constexpr uint8_t dbmReverse = (1 << dbfReverseBlack);    // White pixels in bitmap will be drawn as black pixels on display
                                                         // Black pixels in bitmap will be drawn as white pixels on display
 
-constexpr uint8_t dbmMasked  = _BV(dbfMasked);          // The bitmap contains a mask that will determine which pixels are
+constexpr uint8_t dbmMasked  = (1 << dbfMasked);          // The bitmap contains a mask that will determine which pixels are
                                                         // drawn and which pixels remain unchanged on display
                                                         // (same as sprites drawPlusMask)
-constexpr uint8_t dbmEndFrame = _BV(dbfEndFrame);       // last bitmap of a frame but more frames
-constexpr uint8_t dbmLastFrame = _BV(dbfLastFrame);     // last bitmap of a frame and at end of frames
+constexpr uint8_t dbmEndFrame = (1 << dbfEndFrame);       // last bitmap of a frame but more frames
+constexpr uint8_t dbmLastFrame = (1 << dbfLastFrame);     // last bitmap of a frame and at end of frames
 
 // Note above modes may be combined like (dbmMasked | dbmReverse)
 
@@ -85,15 +85,15 @@ constexpr uint8_t dcfMasked       = 4; // character contains mask data
 constexpr uint8_t dcfProportional = 5; // use fonts width table to mimic proportional characters
 
 //draw Font character modes
-constexpr uint8_t dcmBlack   = _BV(dcfReverseBlack) |   // white pixels in character will be drawn as black pixels on display
-                               _BV(dcfBlack) |          // black pixels in character will not change pixels on display
-                               _BV(dcfWhiteBlack);      // (same as sprites drawErase)
+constexpr uint8_t dcmBlack   = (1 << dcfReverseBlack) |   // white pixels in character will be drawn as black pixels on display
+                               (1 << dcfBlack) |          // black pixels in character will not change pixels on display
+                               (1 << dcfWhiteBlack);      // (same as sprites drawErase)
 
-constexpr uint8_t dcmWhite   = _BV(dcfWhiteBlack);      // white pixels in character will be drawn as white pixels on display
+constexpr uint8_t dcmWhite   = (1 << dcfWhiteBlack);      // white pixels in character will be drawn as white pixels on display
                                                         // black pixels in character will not change pixels on display
                                                         //(same as sprites drawSelfMasked)
 
-constexpr uint8_t dcmInvert  = _BV(dcfInvert);          // when a pixel in character has a different color than on display the
+constexpr uint8_t dcmInvert  = (1 << dcfInvert);          // when a pixel in character has a different color than on display the
                                                         // pixel on display will be drawn as white. In all other cases the
                                                         // pixel will be drawn as black
 // additional drawcharacter modes
@@ -101,12 +101,12 @@ constexpr uint8_t dcmNormal     = 0;                    // White pixels in chara
 constexpr uint8_t dcmOverwrite  = 0;                    // Black pixels in character will be drawn as black pixels on display
                                                         // (Same as sprites drawOverwrite)
 
-constexpr uint8_t dcmReverse = _BV(dcfReverseBlack);    // White pixels in character will be drawn as black pixels on display
+constexpr uint8_t dcmReverse = (1 << dcfReverseBlack);    // White pixels in character will be drawn as black pixels on display
                                                         // Black pixels in character will be drawn as white pixels on display
 
-constexpr uint8_t dcmMasked  = _BV(dcfMasked);          // The character contains a mask that will determine which pixels are
+constexpr uint8_t dcmMasked  = (1 << dcfMasked);          // The character contains a mask that will determine which pixels are
 
-constexpr uint8_t dcmProportional = _BV(dcfProportional); // draw characters with variable spacing. When this mode is used a
+constexpr uint8_t dcmProportional = (1 << dcfProportional); // draw characters with variable spacing. When this mode is used a
                                                           // 256 byte width table must precede the font data
 
 // Note above modes may be combined like (dcmMasked | dcmProportional)
@@ -191,7 +191,7 @@ class FX
     [[gnu::always_inline]]
     static inline void wait() // wait for a pending flash transfer to complete
     {
-      while ((SPSR & _BV(SPIF)) == 0);
+      while ((SPSR & (1 << SPIF)) == 0);
     }
 
     static uint8_t writeByte(uint8_t data); // write a single byte to flash memory.

--- a/src/ArduboyFX.h
+++ b/src/ArduboyFX.h
@@ -1,7 +1,14 @@
 #ifndef ARDUBOYFX_H
 #define ARDUBOYFX_H
 
-#include <Arduboy2.h>
+// For uint8_t, uint16_t
+#include <stdint.h>
+
+// For size_t
+#include <stddef.h>
+
+// For ARDUINO_ARCH_AVR, PORTD, ...
+#include <Arduino.h>
 
 #ifdef CART_CS_RX
   #define FX_PORT PORTD


### PR DESCRIPTION
Untested, but I'm reasonably confident it'll at least compile. (Provided I didn't overlook anything.)

`Arduino.h` is still quite a notable dependency, but a less niche one, so it'll still be easier to port than before, particularly to other Arduino boards.

I was tempted to replace the `_BV`s inside the `.cpp` file as well, but they're all concentrated in `FX:drawBitmap` which already relies on `Arduboy2Base::sBuffer`, so I'm not sure if it's worth it or not.

I still think it would improve readability because `_BV` is quite a niche thing specific to avr-libc compared to the universality of `1 <<`, but practically there probably won't be many people reading the function, let alone modifying it. (At least not for a while anyway.)

Resolves #5.